### PR TITLE
fix snapc-amp makefile

### DIFF
--- a/snapc-amp/Makefile
+++ b/snapc-amp/Makefile
@@ -18,12 +18,13 @@ CLANG             = $(CPPAMP_BUILD)/bin/clang++
 CLANGFLAGS = -I. -O3 -march=bdver2 -g\
            -DHAVE_AMP \
            -I$(CPPAMP_BUILD)/include \
+           -hc \
            -std=c++amp \
-           -I$(CPPAMP_BUILD)/include/c++/v1 \
+           -stdlib=libc++ \
            -Xclang \
            -fhsa-ext -DCXXAMP_ENABLE_HSA=1 \
            -I/usr/lib/openmpi/include
-CLANGLNKFLAGS = -std=c++amp -L$(CPPAMP_BUILD)/lib -Wl,--rpath=$(CPPAMP_BUILD)/lib -lc++ -lcxxrt -ldl -Wl,--whole-archive -lmcwamp -Wl,--no-whole-archive
+CLANGLNKFLAGS = -hc -std=c++amp -L$(CPPAMP_BUILD)/lib -Wl,--rpath=$(CPPAMP_BUILD)/lib -lc++ -lc++abi -ldl -Wl,--whole-archive -lmcwamp -Wl,--no-whole-archive
 MPILIBS = -L/usr/lib/openmpi/lib -lmpi
 LIBS+=$(MPILIBS)
 


### PR DESCRIPTION
The makefile was using compiler flags from an older version of hcc, updated to use the newer flags
