### PR TITLE
Remove c++amp

### DIFF
--- a/hpgmg-amp/Makefile.hcc
+++ b/hpgmg-amp/Makefile.hcc
@@ -25,15 +25,15 @@ MODEL ?= LC
 
 ifeq ($(MODEL),LC)
 HCC_BASE=/opt/rocm/hcc
-CMODE ?= clamp
+CMODE ?= hcc_dgpu
 else
 ifeq ($(MODEL),HSAIL)
 HCC_BASE = /opt/rocm/hcc-hsail
-CMODE ?= hcc
+CMODE ?= hcc_apu
 else
 ifeq ($(MODEL),OLD)
 HCC_BASE = /opt/hcc
-CMODE ?= clamp
+CMODE ?= hcc_dgpu
 else
 HCC_BASE =
 CMODE ?= c99
@@ -46,7 +46,7 @@ endif
 #This should be linked to the right place, but may not be
 #HCC_BASE=/opt/rocm/hcc
 
-ifeq ($(CMODE),clamp)
+ifeq ($(CMODE),hcc_dgpu)
 # Default is for TILE_BKJ
 USE_GPU = -DUSE_GPU
 USE_GPU += -DUSE_GPU_FOR_SMOOTH
@@ -60,7 +60,7 @@ JBS ?= 8
 IBS ?= 32
 TILING= -DGPU_TILE_BLOCKS=$(BBS) -DGPU_TILE_K=$(KBS) -DGPU_TILE_J=$(JBS) -DGPU_TILE_I=$(IBS)
 else
-ifeq ($(CMODE),hcc)
+ifeq ($(CMODE),hcc_apu)
 USE_GPU = -DUSE_GPU
 USE_GPU += -DUSE_GPU_FOR_BLAS
 USE_GPU += -DUSE_GPU_FOR_RESIDUAL
@@ -145,13 +145,13 @@ FCYCLES = -DUSE_FCYCLES=1
 
 BASEEXEC     = hpgmg-fv
 
-ifeq ($(CMODE),hcc)
+ifeq ($(CMODE),hcc_apu)
 CC           = $(HCC_BASE)/bin/hcc
 CC_CPPFLAGS  = $(shell $(HCC_BASE)/bin/hcc-config --install --cxxflags)
 CC_FLAGS     = -x c++ -Xclang -fhsa-ext
 HCCEXEC      = $(BASEEXEC)-$(MODEL)-hcc
 else
-ifeq ($(CMODE),clamp)
+ifeq ($(CMODE),hcc_dgpu)
 CC           = $(HCC_BASE)/bin/clang++
 CC_CPPFLAGS  = $(shell $(HCC_BASE)/bin/hcc-config --install --cxxflags)
 CC_FLAGS     = -x c++ -Xclang -fhsa-ext
@@ -177,10 +177,10 @@ endif
 LMODE        ?= $(CMODE)
 LD           = $(CC)
 
-ifeq ($(LMODE),hcc)
+ifeq ($(LMODE),hcc_apu)
 LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG) $(shell $(HCC_BASE)/bin/hcc-config --install --ldflags)
 else
-ifeq ($(LMODE),clamp)
+ifeq ($(LMODE),hcc_dgpu)
 LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG) $(shell $(HCC_BASE)/bin/hcc-config --install --ldflags)
 else
 LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG)  -lc

--- a/hpgmg-amp/Makefile.hcc
+++ b/hpgmg-amp/Makefile.hcc
@@ -153,7 +153,7 @@ HCCEXEC      = $(BASEEXEC)-$(MODEL)-hcc
 else
 ifeq ($(CMODE),clamp)
 CC           = $(HCC_BASE)/bin/clang++
-CC_CPPFLAGS  = $(shell $(HCC_BASE)/bin/clamp-config --install --cxxflags)
+CC_CPPFLAGS  = $(shell $(HCC_BASE)/bin/hcc-config --install --cxxflags)
 CC_FLAGS     = -x c++ -Xclang -fhsa-ext
 HCCEXEC      = $(BASEEXEC)-$(MODEL)-clamp
 else
@@ -181,7 +181,7 @@ ifeq ($(LMODE),hcc)
 LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG) $(shell $(HCC_BASE)/bin/hcc-config --install --ldflags)
 else
 ifeq ($(LMODE),clamp)
-LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG) $(shell $(HCC_BASE)/bin/clamp-config --install --ldflags)
+LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG) $(shell $(HCC_BASE)/bin/hcc-config --install --ldflags)
 else
 LDFLAGS      = $(VERBOSE) -g $(OPENMP_FLAG)  -lc
 endif

--- a/hpgmg-amp/finite-volume/source/operators/jacobi.c
+++ b/hpgmg-amp/finite-volume/source/operators/jacobi.c
@@ -378,6 +378,7 @@ template <int GHOSTS>void av_smooth(level_type * level, int x_id, int rhs_id, do
 #endif
         }
       PFE_END;
+      HC_WAIT;
       #elif defined(GPU_TILE_DIM)  && (GPU_TILE_DIM==3)
         extent<3> e(nBlocks*kDim,jDim,iDim);
         PFE_TILE3(e,BBS*KBS,JBS,IBS)
@@ -438,6 +439,7 @@ template <int GHOSTS>void av_smooth(level_type * level, int x_id, int rhs_id, do
           const double Ax_n   = apply_op_ijk_gpu;
           lxnp1(0,0,0) = lxn(0,0,0) + weight*llambda(ijk)*(lrhs(ijk)-Ax_n);
         PFE_END;
+        HC_WAIT;
         #elif defined(GPU_TILE_DIM) && (GPU_TILE_DIM==1)
           #define lxn(inck,incj,inci) (x_n_av(box,to_ijk(k+GHOSTS+inck,j+GHOSTS+incj,i+GHOSTS+inci)))
           #define lxnp1(inck,incj,inci) (x_np1_av(box,to_ijk(k+GHOSTS+inck,j+GHOSTS+incj,i+GHOSTS+inci)))
@@ -468,6 +470,7 @@ template <int GHOSTS>void av_smooth(level_type * level, int x_id, int rhs_id, do
             const double Ax_n   = apply_op_ijk_gpu;
             lxnp1(0,0,0) = lxn(0,0,0) + weight*llambda(ijk)*(lrhs(ijk)-Ax_n);
           PFE_END;
+          HC_WAIT;
         #elif !defined(GPU_TILE_DIM) || (GPU_TILE_DIM==0)
           #define lxn(inck,incj,inci) (x_n_av(box,to_ijk(k+GHOSTS+inck,j+GHOSTS+incj,i+GHOSTS+inci)))
           #define lxnp1(inck,incj,inci) (x_np1_av(box,to_ijk(k+GHOSTS+inck,j+GHOSTS+incj,i+GHOSTS+inci)))
@@ -499,6 +502,7 @@ template <int GHOSTS>void av_smooth(level_type * level, int x_id, int rhs_id, do
             const double Ax_n   = apply_op_ijk_gpu;
             lxnp1(0,0,0) = lxn(0,0,0) + weight*llambda(ijk)*(lrhs(ijk)-Ax_n);
           });
+          HC_WAIT;
       #else // GPU_TILE_DIM
         #error Unrecognized combination of GPU_DIM and GPU_TILE_DIM
       #endif // GPU_TILE_DIM


### PR DESCRIPTION
I made some minor changes required to make hpgmg work now that c++amp id deprecated. Maybe we should also think about changing the names of some of these apps (changing hpgmg-amp to hpgmg-hcc for example).